### PR TITLE
HOTFIX - Bug can't escape search box 

### DIFF
--- a/Skyblock Bazzar Tracker/SearchWindow.xaml
+++ b/Skyblock Bazzar Tracker/SearchWindow.xaml
@@ -4,7 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:Skyblock_Bazzar_Tracker" ShowInTaskbar="False" WindowStartupLocation="CenterOwner"
-        mc:Ignorable="d" Background="#FF414E42" AllowsTransparency="True" WindowStyle="None"
+        mc:Ignorable="d" Background="#FF414E42" AllowsTransparency="True" WindowStyle="None" KeyDown="Window_KeyDown" MouseDown="Window_MouseDown"
         Title="SearchWindow" Height="300" Width="600">
     <Grid>
         <Grid.RowDefinitions>
@@ -28,7 +28,7 @@
             <TextBox x:Name="search_box" Background="Transparent" Grid.Column="1"
                      Margin="0,5" FontSize="26" FontWeight="Light" 
                      Foreground="Snow" VerticalAlignment="Center"
-                     BorderThickness="0" TextChanged="search_box_TextChanged"/>
+                     BorderThickness="0" TextChanged="search_box_TextChanged" UndoLimit="10"/>
         </Grid>
         <ListView Grid.Row="1" Background="Transparent" BorderBrush="#FF4A615F"
                   x:Name="List_view" FontSize="20" Foreground="Snow" Margin="20,0"

--- a/Skyblock Bazzar Tracker/SearchWindow.xaml.cs
+++ b/Skyblock Bazzar Tracker/SearchWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Reflection;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
@@ -21,6 +22,13 @@ namespace Skyblock_Bazzar_Tracker
             this.keys_dict = keys_dict;
 
             Closed += (object sender, EventArgs e) => { isClosed = true; };
+            Loaded += _RunOnLoad;
+        }
+
+
+        private void _RunOnLoad(object sender, RoutedEventArgs args)
+        {
+            search_box.Focus();
         }
 
         private void search_box_TextChanged(object sender, TextChangedEventArgs e)
@@ -79,16 +87,59 @@ namespace Skyblock_Bazzar_Tracker
             base.OnDeactivated(e);
             if (!this.IsMouseOver)
             {
-                this.Close();
+                try
+                {
+                    this.Close();
+
+                }
+                catch (Exception excep)
+                {
+                    Debug.WriteLine(excep.Message);
+                }
                 Debug.WriteLine("Search Window Lost Focus");
             }
         }
 
         private void List_view_MouseDoubleClick(object sender, MouseButtonEventArgs e)
         {
-            key_selected = keys_dict[((sender as ListView).SelectedItem as string).ToLower()];
+            _Item_has_Been_selected();   
+        }
+
+        private void _Item_has_Been_selected()
+        {
+            key_selected = keys_dict[(List_view.SelectedItem as string).ToLower()];
             DialogResult = true;
             this.Close();
+
+        }
+
+
+        private void Window_KeyDown(object sender, KeyEventArgs e)
+        {
+            Debug.WriteLine($"[search window] {e.Key.ToString()} key pressed");
+            switch (e.Key )
+            {
+                case Key.Escape:
+                    this.Close();
+                    break;
+                case Key.Enter:
+                    _Item_has_Been_selected();
+                    break;
+            }
+            
+
+        }
+
+        private void Window_MouseDown(object sender, MouseButtonEventArgs e)
+        {
+            Debug.WriteLine("[Search Window] mouse has been pressed ");
+          /// logging the st
+            base.OnDeactivated(e);
+            if (!this.IsMouseOver)
+            {
+                this.Close();
+                Debug.WriteLine("Search Window Lost Focus");
+            }
         }
     }
 }


### PR DESCRIPTION
Bug fixed by adding the ability to press escape and it will close the window
```cs

        private void Window_KeyDown(object sender, KeyEventArgs e)
        {
            Debug.WriteLine($"[search window] {e.Key.ToString()} key pressed");
            switch (e.Key )
            {
                case Key.Escape:
                    this.Close();
                    break;
                case Key.Enter:
                    _Item_has_Been_selected();
                    break;
            }
```